### PR TITLE
Release 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,57 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [unreleased] - 2023-10-08
+## [unreleased] - ####-##-##
 
 ### Added
 - N/A
 
 ### Changed
 - N/A
+
+### Fixed
+- N/A
+
+## [0.2] - 2024-02-13
+
+Updates the `Get-IDSession` command, which can be used to return data from the module scope:
+
+```powershell
+PS C:\> Get-IDSession
+
+Name                           Value
+----                           -----
+tenant_url                     https://abc1234.id.cyberark.cloud
+User                           some.user@somedomain.com
+TenantId                       ABC1234
+SessionId                      1337CbGbPunk3Sm1ff5ess510nD3tai75
+WebSession                     Microsoft.PowerShell.Commands.WebRequestSession
+StartTime                      12/02/2024 22:58:13
+ElapsedTime                    00:25:30
+LastCommand                    System.Management.Automation.InvocationInfo
+LastCommandTime                12/02/2024 23:23:07
+LastCommandResults             {"success":true,"Result":{"SomeResult"}}
+```
+
+Executing this command exports variables like the URL, Username & WebSession object for the authenticated session from IdentityCommand into your local scope, either for use in other requests outside of the module scope, or for informational purposes.
+
+Return data also includes details such as session start time, elapsed time, last command time, as well as data for the last invoked command and the results of the previous command useful for debugging & development purposes.
+
+### Added
+- Private Function `Get-ParentFunction`
+  - Helper function to get command invocation data from different scopes
+- Private Function `Get-SessionClone`
+  - Helper function to create unreferenced copy of IdentityCommand session hashtable object
+
+### Changed
+- `Get-IDSession`
+  - Returns the module scoped `$ISPSSSession` variable (which includes the WebSession object), instead of just the WebSession object.
+- `New-IDSession`
+  - Sets values in the script scope `$ISPSSSession` object instead of individual script scope variables.
+- `Close-IDSession`
+  - Sets null values in the script scope `$ISPSSSession` object instead of removing individual script scope variables.
+- All other functions
+  - Updated entire codebase to reference `$ISPSSSession` object instead of individual script scope variables.
 
 ### Fixed
 - N/A

--- a/IdentityCommand/IdentityCommand.psm1
+++ b/IdentityCommand/IdentityCommand.psm1
@@ -41,3 +41,19 @@ Get-ChildItem $PSScriptRoot\ -Recurse -Include '*.ps1' -Exclude '*.ps1xml' |
         }
 
     }
+
+# Script scope session object for session data
+$ISPSSSession = [ordered]@{
+    tenant_url         = $null
+    User               = $null
+    TenantId           = $null
+    SessionId          = $null
+    WebSession         = $null
+    StartTime          = $null
+    ElapsedTime        = $null
+    LastCommand        = $null
+    LastCommandTime    = $null
+    LastCommandResults = $null
+} | Add-CustomType -Type IdCmd.Session
+
+New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force

--- a/IdentityCommand/Private/Clear-AdvanceAuthentication.ps1
+++ b/IdentityCommand/Private/Clear-AdvanceAuthentication.ps1
@@ -26,15 +26,15 @@ Function Clear-AdvanceAuthentication {
     Process {
 
         $Body = @{
-            TenantId  = $Script:TenantId
-            SessionId = $Script:SessionId
+            TenantId  = $ISPSSSession.TenantId
+            SessionId = $ISPSSSession.SessionId
         }
 
-        $LogonRequest['Uri'] = "$Script:tenant_url/Security/CleanupAuthentication"
+        $LogonRequest['Uri'] = "$($ISPSSSession.tenant_url)/Security/CleanupAuthentication"
         $LogonRequest['Method'] = 'POST'
         $LogonRequest['Body'] = $Body | ConvertTo-Json
 
-        if ($PSCmdlet.ShouldProcess($Script:SessionId, 'Clear Authentication Session')) {
+        if ($PSCmdlet.ShouldProcess($($ISPSSSession.SessionId), 'Clear Authentication Session')) {
 
             Invoke-IDRestMethod @LogonRequest | Out-Null
 

--- a/IdentityCommand/Private/Complete-SamlAuthentication.ps1
+++ b/IdentityCommand/Private/Complete-SamlAuthentication.ps1
@@ -36,9 +36,9 @@ Function Complete-SamlAuthentication {
         #Setup request. This command will return html, so supress output/html error detection
         $Script:ExpectHtml = $true
         $LogonRequest['Method'] = 'GET'
-        $LogonRequest['Uri'] = "$Script:tenant_url/login"
+        $LogonRequest['Uri'] = "$($ISPSSSession.tenant_url)/login"
 
-        if ($PSCmdlet.ShouldProcess($Script:tenant_url, 'Send Assertion')) {
+        if ($PSCmdlet.ShouldProcess($ISPSSSession.tenant_url, 'Send Assertion')) {
 
             try {
 

--- a/IdentityCommand/Private/Get-ParentFunction.ps1
+++ b/IdentityCommand/Private/Get-ParentFunction.ps1
@@ -1,0 +1,58 @@
+Function Get-ParentFunction {
+	<#
+	.SYNOPSIS
+	Returns details of the calling function from a variable scope
+
+	.DESCRIPTION
+	Returns the FunctionName and the ParameterSetName which was used to invoke another function
+
+	.PARAMETER Scope
+	The Scope number from which to return the calling functions details.
+
+	.EXAMPLE
+	Function Test-Parent {Test-Child}
+	Function Test-Child {Get-ParentFunction}
+	$example = Test-Parent
+
+	$example.FunctionName #Returns Test-Parent
+
+	.EXAMPLE
+	Function Test-Example {
+		[CmdletBinding()]
+		param([parameter(ParameterSetName = "ExampleParamSet")][string]$Name)
+			Test-Parent
+	}
+	Function Test-Parent {Test-Child}
+	Function Test-Child {Get-ParentFunction -Scope 3}
+	$example = Test-Example -Name "test"
+
+	$example.Function #Returns "Test-Example"
+	$example.ParameterSetName #Returns "ExampleParamSet"
+
+	.NOTES
+
+	#>
+	[CmdletBinding()]
+	Param(
+		# The scope number from which to retrieve the parent function name
+		[Parameter(
+			Mandatory = $false,
+			ValueFromPipelineByPropertyName = $true
+		)]
+		[Int]
+		$Scope = 2
+	)
+
+	Process {
+
+		#Get MyInvocation details from required scope
+		$CommandData = (Get-Variable MyInvocation -Scope $Scope).Value
+		[PSCustomObject]@{
+			CommandData      = $CommandData
+			FunctionName     = $CommandData.MyCommand.Name
+			ParameterSetName = (Get-Variable PSCmdlet -Scope $Scope -ErrorAction SilentlyContinue).Value.ParameterSetName
+		}
+
+	}
+
+}

--- a/IdentityCommand/Private/Get-SessionClone.ps1
+++ b/IdentityCommand/Private/Get-SessionClone.ps1
@@ -1,0 +1,46 @@
+function Get-SessionClone {
+    <#
+    .SYNOPSIS
+    Deep copy a hashtable
+
+    .DESCRIPTION
+    Deep copy a hashtable or ordered dictionary, and return an ordered dictionary
+
+    .PARAMETER InputObject
+    A hashtable or OrderedDictionary to clone
+
+    .EXAMPLE
+    Get-SessionClone -InputObject $Hashtable
+
+    Returns a new ordered hashtable, which is a deep copy of $Hashtable
+
+    .OUTPUTS
+    System.Collections.Specialized.OrderedDictionary
+    #>
+    [cmdletbinding()]
+    [OutputType('System.Collections.Specialized.OrderedDictionary')]
+    param(
+        [parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true
+        )]
+        $InputObject
+    )
+    process {
+        if (($InputObject -is [hashtable]) -or ($InputObject -is [System.Collections.Specialized.OrderedDictionary])) {
+            $clone = [ordered]@{}
+            foreach ($key in $InputObject.keys) {
+                if ($null -ne $InputObject[$key]) {
+                    $clone[$key] = Get-SessionClone $InputObject[$key]
+                } else {
+                    $clone[$key] = $null
+                }
+            }
+            return $clone
+        } else {
+
+            return $InputObject
+
+        }
+    }
+}

--- a/IdentityCommand/Private/Invoke-IDRestMethod.ps1
+++ b/IdentityCommand/Private/Invoke-IDRestMethod.ps1
@@ -9,7 +9,7 @@
 	queried and acted on.
 	All requests are sent with ContentType=application/json.
 	If the sessionVariable parameter is passed, the function will return the WebSession
-	object to the $Script:WebSession variable.
+	object to the $ISPSSSession.WebSession variable.
 
 	.PARAMETER Method
 	The method for the REST Method.
@@ -27,7 +27,7 @@
 	.PARAMETER SessionVariable
 	If passed, will be sent to invoke-webrequest which in turn will create a websession
 	variable using the string value as the name. This variable will only exist in the current scope
-	so will be set as the value of $Script:WebSession to be available in a modules scope.
+	so will be set as the value of $ISPSSSession.WebSession to be available in a modules scope.
 	Cannot be specified with WebSession
 
 	.PARAMETER WebSession
@@ -61,7 +61,7 @@
 	An Accept string to be included in the request header
 
 	.EXAMPLE
-	Invoke-IDRestMethod -Uri $URI -Method DELETE -WebSession $Script:WebSession
+	Invoke-IDRestMethod -Uri $URI -Method DELETE -WebSession $ISPSSSession.WebSession
 
 	Send request to web service
 	#>
@@ -121,12 +121,12 @@
 		$ProgressPreference = 'SilentlyContinue'
 		$PSBoundParameters.Add('UseBasicParsing', $true)
 
-		if ($null -ne $Script:WebSession) {
+		if ($null -ne $ISPSSSession.WebSession) {
 
 			#use the WebSession if it exists in the module scope, and alternate session is not specified.
 			if ( -not ($PSBoundParameters.ContainsKey('WebSession'))) {
 
-				$PSBoundParameters.Add('WebSession', $Script:WebSession)
+				$PSBoundParameters.Add('WebSession', $ISPSSSession.WebSession)
 
 			}
 
@@ -229,11 +229,16 @@
 
 		} finally {
 
+			#Add Command Data to $ISPSSSession module scope variable
+			$ISPSSSession.LastCommand = Get-ParentFunction | Select-Object -ExpandProperty CommandData
+			$ISPSSSession.LastCommandResults = $APIResponse
+			$ISPSSSession.LastCommandTime = Get-Date
+
 			#If Session Variable passed as argument
 			If ($PSCmdlet.ParameterSetName -eq 'SessionVariable') {
 
 				#Make the WebSession available in the module scope
-				Set-Variable -Name WebSession -Value $(Get-Variable $(Get-Variable sessionVariable).Value).Value -Scope Script
+				$ISPSSSession.WebSession = $(Get-Variable $(Get-Variable sessionVariable).Value).Value
 
 			}
 

--- a/IdentityCommand/Private/Out-QRImage.ps1
+++ b/IdentityCommand/Private/Out-QRImage.ps1
@@ -44,7 +44,7 @@ function Out-QRImage {
         }
 
         #Get filename from Content-Disposition Header element.
-        $FileName = "$Script:SessionId.html"
+        $FileName = "$($ISPSSSession.SessionId).html"
 
         #Define output path
         $OutputPath = Join-Path $Path $FileName

--- a/IdentityCommand/Private/Start-AdvanceAuthentication.ps1
+++ b/IdentityCommand/Private/Start-AdvanceAuthentication.ps1
@@ -57,15 +57,15 @@ Function Start-AdvanceAuthentication {
 
     Process {
 
-        $LogonRequest['Uri'] = "$Script:tenant_url/Security/AdvanceAuthentication"
+        $LogonRequest['Uri'] = "$($ISPSSSession.tenant_url)/Security/AdvanceAuthentication"
 
         $Body = @{
-            TenantId    = $Script:TenantId
-            SessionId   = $Script:SessionId
+            TenantId    = $ISPSSSession.TenantId
+            SessionId   = $ISPSSSession.SessionId
             MechanismId = $($Mechanism.MechanismId)
         }
 
-        if ($PSCmdlet.ShouldProcess($Script:tenant_url, 'Advance Authentication')) {
+        if ($PSCmdlet.ShouldProcess($($ISPSSSession.tenant_url), 'Advance Authentication')) {
 
             try {
 
@@ -138,7 +138,7 @@ Function Start-AdvanceAuthentication {
     End {
 
         #Maybe there is a QR Image to clear up
-        Remove-Item $(Join-Path $([System.IO.Path]::GetTempPath()) "$Script:SessionId.html") -ErrorAction SilentlyContinue
+        Remove-Item $(Join-Path $([System.IO.Path]::GetTempPath()) "$($ISPSSSession.SessionId).html") -ErrorAction SilentlyContinue
 
     }
 

--- a/IdentityCommand/Private/Start-Authentication.ps1
+++ b/IdentityCommand/Private/Start-Authentication.ps1
@@ -45,7 +45,7 @@ Function Start-Authentication {
 
     process {
 
-        $LogonRequest['Uri'] = "$Script:tenant_url/Security/StartAuthentication"
+        $LogonRequest['Uri'] = "$($ISPSSSession.tenant_url)/Security/StartAuthentication"
 
         $LogonRequest['Body'] = @{
 
@@ -54,7 +54,7 @@ Function Start-Authentication {
 
         } | ConvertTo-Json
 
-        if ($PSCmdlet.ShouldProcess($Script:tenant_url, 'Start Authentication')) {
+        if ($PSCmdlet.ShouldProcess($($ISPSSSession.tenant_url), 'Start Authentication')) {
 
             try {
 
@@ -65,11 +65,11 @@ Function Start-Authentication {
 
                     #Redirect URL has been returned
                     #update module scope variables
-                    Clear-Variable -Name tenant_url -Scope Script
-                    Remove-Variable -Name WebSession -Scope Script
-                    Set-Variable -Name tenant_url -Value "https://$($IDSession.PodFqdn)" -Scope Script
+                    $ISPSSSession.tenant_url = $null
+                    $ISPSSSession.WebSession = $null
+                    $ISPSSSession.tenant_url = "https://$($IDSession.PodFqdn)"
 
-                    $LogonRequest['Uri'] = "$Script:tenant_url/Security/StartAuthentication"
+                    $LogonRequest['Uri'] = "$($ISPSSSession.tenant_url)/Security/StartAuthentication"
 
                     #Perform Start Authentication with new URL
                     $IDSession = Invoke-IDRestMethod @LogonRequest

--- a/IdentityCommand/Private/Start-SamlAuthentication.ps1
+++ b/IdentityCommand/Private/Start-SamlAuthentication.ps1
@@ -48,7 +48,7 @@ Function Start-SamlAuthentication {
         #Setup request. This command will return html, so supress output/html error detection
         $Script:ExpectHtml = $true
         $LogonRequest['ContentType'] = 'application/x-www-form-urlencoded'
-        $LogonRequest['Uri'] = "$Script:tenant_url/my"
+        $LogonRequest['Uri'] = "$($ISPSSSession.tenant_url)/my"
 
         $LogonRequest['Body'] = @{
 
@@ -56,7 +56,7 @@ Function Start-SamlAuthentication {
 
         }
 
-        if ($PSCmdlet.ShouldProcess($Script:tenant_url, 'Send SAML Assertion')) {
+        if ($PSCmdlet.ShouldProcess($($ISPSSSession.tenant_url), 'Send SAML Assertion')) {
 
             try {
 

--- a/IdentityCommand/Public/Clear-IDUserSession.ps1
+++ b/IdentityCommand/Public/Clear-IDUserSession.ps1
@@ -15,7 +15,7 @@ function Clear-IDUserSession {
 
     PROCESS {
 
-        $URI = "$Script:tenant_url/UserMgmt/SignOutEverywhere?$($PSBoundParameters | Get-Parameter | ConvertTo-QueryString)"
+        $URI = "$($ISPSSSession.tenant_url)/UserMgmt/SignOutEverywhere?$($PSBoundParameters | Get-Parameter | ConvertTo-QueryString)"
 
         #Send Logoff Request
         Invoke-IDRestMethod -Uri $URI -Method POST

--- a/IdentityCommand/Public/Close-IDSession.ps1
+++ b/IdentityCommand/Public/Close-IDSession.ps1
@@ -5,7 +5,7 @@ function Close-IDSession {
 
     BEGIN {
 
-        $URI = "$Script:tenant_url/Security/Logout"
+        $URI = "$($ISPSSSession.tenant_url)/Security/Logout"
 
     }#begin
 
@@ -19,9 +19,12 @@ function Close-IDSession {
     END {
 
         #Remove Module scope variables on logoff
-        Remove-Variable -Name tenant_url -Scope Script -ErrorAction SilentlyContinue
-        Remove-Variable -Name TenantId -Scope Script -ErrorAction SilentlyContinue
-        Remove-Variable -Name WebSession -Scope Script -ErrorAction SilentlyContinue
+        $ISPSSSession.tenant_url = $null
+        $ISPSSSession.TenantId = $null
+        $ISPSSSession.WebSession = $null
+        $ISPSSSession.User = $null
+        $ISPSSSession.StartTime = $null
+        $ISPSSSession.SessionId = $null
 
     }#end
 

--- a/IdentityCommand/Public/Get-IDAnalyticsDataset.ps1
+++ b/IdentityCommand/Public/Get-IDAnalyticsDataset.ps1
@@ -5,7 +5,7 @@ function Get-IDAnalyticsDataset {
 
     BEGIN {
 
-        $URI = "$Script:tenant_url/analytics/services/v1.0/dataset"
+        $URI = "$($ISPSSSession.tenant_url)/analytics/services/v1.0/dataset"
 
     }#begin
 

--- a/IdentityCommand/Public/Get-IDConnector.ps1
+++ b/IdentityCommand/Public/Get-IDConnector.ps1
@@ -15,7 +15,7 @@ function Get-IDConnector {
 
     PROCESS {
 
-        $URI = "$Script:tenant_url/Core/CheckProxyHealth"
+        $URI = "$($ISPSSSession.tenant_url)/Core/CheckProxyHealth"
 
         $queryString = $PSBoundParameters | Get-Parameter | ConvertTo-QueryString
 

--- a/IdentityCommand/Public/Get-IDDownloadUrl.ps1
+++ b/IdentityCommand/Public/Get-IDDownloadUrl.ps1
@@ -5,7 +5,7 @@ function Get-IDDownloadUrl {
 
     BEGIN {
 
-        $URI = "$Script:tenant_url/Core/GetDownloadUrls"
+        $URI = "$($ISPSSSession.tenant_url)/Core/GetDownloadUrls"
 
     }#begin
 

--- a/IdentityCommand/Public/Get-IDSession.ps1
+++ b/IdentityCommand/Public/Get-IDSession.ps1
@@ -4,6 +4,20 @@ Function Get-IDSession {
     [CmdletBinding()]
     Param ()
 
-    Get-Variable -Name WebSession -Scope Script -ValueOnly
+    BEGIN { }#begin
+
+    PROCESS {
+
+        #Calculate the time elapsed since the start of the session and include in return data
+        if ($null -ne $ISPSSSession.StartTime) {
+            $ISPSSSession.ElapsedTime = '{0:HH:mm:ss}' -f ([datetime]$($(Get-Date) - $($ISPSSSession.StartTime)).Ticks)
+        } else { $ISPSSSession.ElapsedTime = $null }
+
+        #Deep Copy the $psPASSession session object and return as psPAS Session type.
+        Get-SessionClone -InputObject $ISPSSSession | Add-CustomType -Type IdCmd.Session
+
+    }#process
+
+    END { }#end
 
 }

--- a/IdentityCommand/Public/Get-IDTenant.ps1
+++ b/IdentityCommand/Public/Get-IDTenant.ps1
@@ -5,7 +5,7 @@ function Get-IDTenant {
 
     BEGIN {
 
-        $URI = "$Script:tenant_url/SysInfo/About"
+        $URI = "$($ISPSSSession.tenant_url)/SysInfo/About"
 
     }#begin
 

--- a/IdentityCommand/Public/Get-IDTenantCname.ps1
+++ b/IdentityCommand/Public/Get-IDTenantCname.ps1
@@ -5,7 +5,7 @@ function Get-IDTenantCname {
 
     BEGIN {
 
-        $URI = "$Script:tenant_url/TenantCnames/UiGet"
+        $URI = "$($ISPSSSession.tenant_url)/TenantCnames/UiGet"
 
     }#begin
 

--- a/IdentityCommand/Public/Get-IDTenantConfiguration.ps1
+++ b/IdentityCommand/Public/Get-IDTenantConfiguration.ps1
@@ -5,7 +5,7 @@ function Get-IDTenantConfiguration {
 
     BEGIN {
 
-        $URI = "$Script:tenant_url/TenantConfig/GetCustomerConfig"
+        $URI = "$($ISPSSSession.tenant_url)/TenantConfig/GetCustomerConfig"
 
     }#begin
 

--- a/IdentityCommand/Public/Get-IDUser.ps1
+++ b/IdentityCommand/Public/Get-IDUser.ps1
@@ -40,7 +40,7 @@ Function Get-IDUser {
     BEGIN {
         #ParameterSet name matches URL portion for different requests
         $Request = @{}
-        $Request['URI'] = "$Script:tenant_url/CDirectoryService/$($PSCmdlet.ParameterSetName)"
+        $Request['URI'] = "$($ISPSSSession.tenant_url)/CDirectoryService/$($PSCmdlet.ParameterSetName)"
         $Request['Method'] = 'POST'
     }#begin
 

--- a/IdentityCommand/Public/Get-IDUserIdentifier.ps1
+++ b/IdentityCommand/Public/Get-IDUserIdentifier.ps1
@@ -5,7 +5,7 @@ function Get-IDUserIdentifier {
 
     BEGIN {
 
-        $URI = "$Script:tenant_url/UserIdentifiers/Get"
+        $URI = "$($ISPSSSession.tenant_url)/UserIdentifiers/Get"
 
     }#begin
 

--- a/IdentityCommand/Public/Get-IDUserRole.ps1
+++ b/IdentityCommand/Public/Get-IDUserRole.ps1
@@ -54,7 +54,7 @@ function Get-IDUserRole {
         $URLParameters = $PSBoundParameters | Get-Parameter -ParametersToKeep ID
         $BoundParameters = $PSBoundParameters | Get-Parameter -ParametersToRemove ID
 
-        $URI = "$Script:tenant_url/UserMgmt/GetUsersRolesAndAdministrativeRights?$($URLParameters | ConvertTo-QueryString)"
+        $URI = "$($ISPSSSession.tenant_url)/UserMgmt/GetUsersRolesAndAdministrativeRights?$($URLParameters | ConvertTo-QueryString)"
 
         $Body = @{'Args' = $BoundParameters } | ConvertTo-Json
 

--- a/IdentityCommand/Public/Invoke-IDSqlcmd.ps1
+++ b/IdentityCommand/Public/Invoke-IDSqlcmd.ps1
@@ -55,7 +55,7 @@ function Invoke-IDSqlcmd {
 
     PROCESS {
 
-        $URI = "$Script:tenant_url/Redrock/query"
+        $URI = "$($ISPSSSession.tenant_url)/Redrock/query"
 
         #Create request body with Script & args properties
         $Cmd = $PSBoundParameters | Get-Parameter -ParametersToKeep Script

--- a/IdentityCommand/Public/Lock-IDUser.ps1
+++ b/IdentityCommand/Public/Lock-IDUser.ps1
@@ -19,7 +19,7 @@ function Lock-IDUser {
 
         $BoundParameters = ($PSBoundParameters | Get-Parameter) + $Action
 
-        $URI = "$Script:tenant_url/UserMgmt/SetCloudLock?$($BoundParameters | ConvertTo-QueryString)"
+        $URI = "$($ISPSSSession.tenant_url)/UserMgmt/SetCloudLock?$($BoundParameters | ConvertTo-QueryString)"
 
         #Send Unlock Request
         $result = Invoke-IDRestMethod -Uri $URI -Method POST

--- a/IdentityCommand/Public/New-IDPlatformToken.ps1
+++ b/IdentityCommand/Public/New-IDPlatformToken.ps1
@@ -21,7 +21,7 @@ Function New-IDPlatformToken {
 
     Begin {
         #Remove WebSession which may exist in module scope
-        Remove-Variable -Name WebSession -Scope Script -ErrorAction SilentlyContinue
+        $ISPSSSession.WebSession = $null
 
         $LogonRequest = @{ }
         $LogonRequest['Method'] = 'POST'
@@ -35,9 +35,9 @@ Function New-IDPlatformToken {
         $tenant_url = $tenant_url -replace '/$', ''
 
         #Set Module Scope variables
-        Set-Variable -Name tenant_url -Value $tenant_url -Scope Script
+        $ISPSSSession.tenant_url = $tenant_url
 
-        $LogonRequest['Uri'] = "$Script:tenant_url/OAuth2/PlatformToken"
+        $LogonRequest['Uri'] = "$($ISPSSSession.tenant_url)/OAuth2/PlatformToken"
         $LogonRequest['Headers'] = @{'accept' = '*/*' }
         $LogonRequest['ContentType'] = 'application/x-www-form-urlencoded'
         $LogonRequest['Body'] = @{
@@ -51,7 +51,7 @@ Function New-IDPlatformToken {
 
         }
 
-        if ($PSCmdlet.ShouldProcess($Script:tenant_url, 'Request Platform Token')) {
+        if ($PSCmdlet.ShouldProcess($($ISPSSSession.tenant_url), 'Request Platform Token')) {
 
             #*Get OIDC token based on grant type
             $IDSession = Invoke-IDRestMethod @LogonRequest
@@ -63,7 +63,7 @@ Function New-IDPlatformToken {
                 #Add GetWebSession ScriptMethod
                 $result | Add-Member -MemberType ScriptMethod -Name GetWebSession -Value {
 
-                    Get-IDSession
+                    Get-IDSession | Select-Object -ExpandProperty WebSession
 
                 } -Force
 

--- a/IdentityCommand/Public/Suspend-IDUserMFA.ps1
+++ b/IdentityCommand/Public/Suspend-IDUserMFA.ps1
@@ -22,7 +22,7 @@ function Suspend-IDUserMFA {
 
     PROCESS {
 
-        $URI = "$Script:tenant_url/CDirectoryService/ExemptUserFromMfa?$($PSBoundParameters | Get-Parameter | ConvertTo-QueryString)"
+        $URI = "$($ISPSSSession.tenant_url)/CDirectoryService/ExemptUserFromMfa?$($PSBoundParameters | Get-Parameter | ConvertTo-QueryString)"
 
         #Send Request
         Invoke-IDRestMethod -Uri $URI -Method POST

--- a/IdentityCommand/Public/Test-IDUserCloudLock.ps1
+++ b/IdentityCommand/Public/Test-IDUserCloudLock.ps1
@@ -15,7 +15,7 @@ function Test-IDUserCloudLock {
 
     PROCESS {
 
-        $URI = "$Script:tenant_url/UserMgmt/IsUserCloudLocked?$($PSBoundParameters | Get-Parameter | ConvertTo-QueryString)"
+        $URI = "$($ISPSSSession.tenant_url)/UserMgmt/IsUserCloudLocked?$($PSBoundParameters | Get-Parameter | ConvertTo-QueryString)"
 
         #Send Request
         $result = Invoke-IDRestMethod -Uri $URI -Method POST

--- a/IdentityCommand/Public/Unlock-IDUser.ps1
+++ b/IdentityCommand/Public/Unlock-IDUser.ps1
@@ -19,7 +19,7 @@ function Unlock-IDUser {
 
         $BoundParameters = ($PSBoundParameters | Get-Parameter) + $Action
 
-        $URI = "$Script:tenant_url/UserMgmt/SetCloudLock?$($BoundParameters | ConvertTo-QueryString)"
+        $URI = "$($ISPSSSession.tenant_url)/UserMgmt/SetCloudLock?$($BoundParameters | ConvertTo-QueryString)"
 
         #Send Unlock Request
         $result = Invoke-IDRestMethod -Uri $URI -Method POST

--- a/IdentityCommand/about_IdentityCommand.help.txt
+++ b/IdentityCommand/about_IdentityCommand.help.txt
@@ -15,7 +15,7 @@ EXAMPLES
     An example command to initiate authentication to a specified tenant is shown here:
 
     PS C:\> $Credential = Get-Credential
-    PS C:\> New-IDSession -tenant_url https://some.tenant.cyberark.cloud -Credential $Credential
+    PS C:\> New-IDSession -tenant_url https://sometenant.id.cyberark.cloud -Credential $Credential
 
     This allows initial authentication to progress as well as selection and answer of any required MFA challenges.
 
@@ -27,7 +27,7 @@ EXAMPLES
 
     The GetToken method of the object returned on successful authentication can be invoked to obtain a bearer token to be used for further requests.
 
-    PS C:\> $Session = New-IDSession -tenant_url https://some.tenant.cyberark.cloud -Credential $Credential
+    PS C:\> $Session = New-IDSession -tenant_url https://sometenant.id.cyberark.cloud -Credential $Credential
     PS C:\> $Session.GetToken()
 
     Name                           Value
@@ -38,7 +38,7 @@ EXAMPLES
 
     The GetWebSession method can be used in a similar way to GetToken, but the websession object for the authenticated session is returned instead of a Bearer token.
 
-    PS C:\> $Session = New-IDSession -tenant_url https://some.tenant.cyberark.cloud -Credential $Credential
+    PS C:\> $Session = New-IDSession -tenant_url https://sometenant.id.cyberark.cloud -Credential $Credential
     PS C:\> $session.GetWebSession()
 
     Headers               : {[accept, */*], [X-IDAP-NATIVE-CLIENT, True]}

--- a/IdentityCommand/en-US/IdentityCommand-help.xml
+++ b/IdentityCommand/en-US/IdentityCommand-help.xml
@@ -266,7 +266,8 @@
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Exports the WebSession object from the IdentityCommand module scope for use in other requests outside of the module scope.</maml:para>
+      <maml:para>Exports variables like the URL, Username &amp; WebSession object from the IdentityCommand module scope, either for use in other requests outside of the module scope, or for informational purposes.</maml:para>
+      <maml:para>Return data also includes details such as session start time, elapsed time, last command time, as well as data for the last invoked command and the results of the previous command.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -284,9 +285,22 @@
     <command:examples>
       <command:example>
         <maml:title>-------------------------- Example 1 --------------------------</maml:title>
-        <dev:code>PS C:\&gt; Get-IDSession</dev:code>
+        <dev:code>PS C:\&gt; Get-IDSession
+
+Name                           Value
+----                           -----
+tenant_url                     https://abc1234.id.cyberark.cloud
+User                           some.user@somedomain.com
+TenantId                       ABC1234
+SessionId                      1337CbGbPunk3Sm1ff5ess510nD3tai75
+WebSession                     Microsoft.PowerShell.Commands.WebRequestSession
+StartTime                      12/02/2024 22:58:13
+ElapsedTime                    00:25:30
+LastCommand                    System.Management.Automation.InvocationInfo
+LastCommandTime                12/02/2024 23:23:07
+LastCommandResults             {"success":true,"Result":{"SomeResult"}}</dev:code>
         <dev:remarks>
-          <maml:para>Output the IdentityCommand WebSession object for the current authenticated session.</maml:para>
+          <maml:para>Output the IdentityCommand module scope session details, including the WebSession object for the current authenticated session.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/README.md
+++ b/README.md
@@ -95,6 +95,30 @@ PS C:\> Invoke-RestMethod -WebSession $websession `
 -Uri https://somedomain.id.cyberark.cloud `
 -Body @{SomeProperty = 'SomeValue'} | ConvertTo-Json
 ```
+### Module Scope Variables & Command  Invocation Data
+
+The `Get-IDSession` command can be used to return data from the module scope:
+
+```powershell
+PS C:\> Get-IDSession
+
+Name                           Value
+----                           -----
+tenant_url                     https://abc1234.id.cyberark.cloud
+User                           some.user@somedomain.com
+TenantId                       ABC1234
+SessionId                      1337CbGbPunk3Sm1ff5ess510nD3tai75
+WebSession                     Microsoft.PowerShell.Commands.WebRequestSession
+StartTime                      12/02/2024 22:58:13
+ElapsedTime                    00:25:30
+LastCommand                    System.Management.Automation.InvocationInfo
+LastCommandTime                12/02/2024 23:23:07
+LastCommandResults             {"success":true,"Result":{"SomeResult"}}
+```
+
+Executing this command exports variables like the URL, Username & WebSession object for the authenticated session from IdentityCommand into your local scope, either for use in other requests outside of the module scope, or for informational purposes.
+
+Return data also includes details such as session start time, elapsed time, last command time, as well as data for the last invoked command and the results of the previous command.
 
 ## List Of Commands
 
@@ -105,7 +129,7 @@ The commands currently available in the _IdentityCommand_ module are listed here
 | `New-IDSession`             | Authenticate to CyberArk Identity, answering MFA challenges to start a new API session.     |
 | `Close-IDSession`           | Logoff CyberArk Identity API                                                                |
 | `Clear-IDUserSession`       | Signs out user from all active sessions                                                     |
-| `Get-IDSession`             | Get WebSession object from the module scope                                                 |
+| `Get-IDSession`             | Get variables like the WebSession object from the module scope, as well as previously invoked command and API return data.                                                  |
 | `Get-IDUser`                | Fetch details of cloud directory users                                                      |
 | `Suspend-IDUserMFA`         | Exempt a user from MFA                                                                      |
 | `Test-IDUserCloudLock`      | Checks if a user is cloud locked                                                            |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You may have a scenario where you want to use APIs for which we have not yet dev
 The GetToken method of the object returned on successful authentication can be invoked to obtain a bearer token to be used for further requests.
 
 ```powershell
-PS C:\> $Session = New-IDPlatformToken -tenant_url https://some.tenant.cyberark.cloud -Credential $Credential
+PS C:\> $Session = New-IDPlatformToken -tenant_url https://sometenant.id.cyberark.cloud -Credential $Credential
 PS C:\> $Session.GetToken()
 
 Name                           Value
@@ -73,7 +73,7 @@ Authorization                  Bearer eyPhbSciPiJEUzT1NEIsInR5cCI6IkpXYZ...
 The GetWebSession method can be used in a similar way to GetToken, except this method returns the websession object for the authenticated session instead of a Bearer token.
 
 ```powershell
-PS C:\> $Session = New-IDSession -tenant_url https://some.tenant.cyberark.cloud -Credential $Credential
+PS C:\> $Session = New-IDSession -tenant_url https://sometenant.id.cyberark.cloud -Credential $Credential
 PS C:\> $session.GetWebSession()
 
 Headers               : {[accept, */*], [X-IDAP-NATIVE-CLIENT, True]}

--- a/Tests/Clear-AdvanceAuthentication.Tests.ps1
+++ b/Tests/Clear-AdvanceAuthentication.Tests.ps1
@@ -24,9 +24,18 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-            $Script:TenantId = 'SomeTenant'
-            $Script:SessionId = 'SomeSession'
-            $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
             Mock Invoke-IDRestMethod -MockWith {
 
             }

--- a/Tests/Clear-IDUserSession.Tests.ps1
+++ b/Tests/Clear-IDUserSession.Tests.ps1
@@ -28,7 +28,21 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             }
 
-            $response = Clear-IDUserSession -id 1234
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
+
+            $response = Clear-IDUserSession -ID 1234
 
         }
 

--- a/Tests/Close-IDSession.Tests.ps1
+++ b/Tests/Close-IDSession.Tests.ps1
@@ -32,6 +32,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             }
 
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = 'SomeUser'
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = (Get-Date).AddMinutes(-5)
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
             $response = Close-IDSession
 
         }
@@ -67,18 +80,12 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
             }
 
             It 'removes the expected module scope variables' {
-                Assert-MockCalled -CommandName Remove-Variable -Times 3 -Exactly -Scope It -ParameterFilter {
-                    $Name -eq 'tenant_url'
-                    $Scope -eq 'Script'
-                }
-                Assert-MockCalled -CommandName Remove-Variable -Times 3 -Exactly -Scope It -ParameterFilter {
-                    $Name -eq 'WebSession'
-                    $Scope -eq 'Script'
-                }
-                Assert-MockCalled -CommandName Remove-Variable -Times 3 -Exactly -Scope It -ParameterFilter {
-                    $Name -eq 'TenantId'
-                    $Scope -eq 'Script'
-                }
+                $Script:ISPSSSession.tenant_url | Should -BeNullOrEmpty
+                $Script:ISPSSSession.TenantId | Should -BeNullOrEmpty
+                $Script:ISPSSSession.WebSession | Should -BeNullOrEmpty
+                $Script:ISPSSSession.User | Should -BeNullOrEmpty
+                $Script:ISPSSSession.StartTime | Should -BeNullOrEmpty
+                $Script:ISPSSSession.SessionId | Should -BeNullOrEmpty
             }
 
         }

--- a/Tests/Complete-SamlAuthentication.Tests.ps1
+++ b/Tests/Complete-SamlAuthentication.Tests.ps1
@@ -25,8 +25,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
         BeforeEach {
             $Script:Version = '1.0'
-            $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
-            $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
             $LogonRequest = @{ }
             $LogonRequest['Method'] = 'POST'
             $LogonRequest['SessionVariable'] = 'IDSession'

--- a/Tests/Get-IDAnalyticsDataset.Tests.ps1
+++ b/Tests/Get-IDAnalyticsDataset.Tests.ps1
@@ -28,6 +28,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 [pscustomobject]@{'property' = 'value' }
             }
 
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
             $response = Get-IDAnalyticsDataset
 
         }

--- a/Tests/Get-IDConnector.Tests.ps1
+++ b/Tests/Get-IDConnector.Tests.ps1
@@ -33,7 +33,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                         )
                     }
                 }
-                $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
+                $ISPSSSession = [ordered]@{
+                    tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                    User               = $null
+                    TenantId           = 'SomeTenant'
+                    SessionId          = 'SomeSession'
+                    WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                    StartTime          = $null
+                    ElapsedTime        = $null
+                    LastCommand        = $null
+                    LastCommandTime    = $null
+                    LastCommandResults = $null
+                }
+                New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
                 $response = Get-IDConnector
 
             }

--- a/Tests/Get-IDDownloadUrl.Tests.ps1
+++ b/Tests/Get-IDDownloadUrl.Tests.ps1
@@ -24,6 +24,20 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
+
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
             Mock Invoke-IDRestMethod -MockWith {
                 [pscustomobject]@{'property' = 'value' }
             }

--- a/Tests/Get-IDSession.Tests.ps1
+++ b/Tests/Get-IDSession.Tests.ps1
@@ -25,40 +25,41 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
         BeforeEach {
 
-            Mock -CommandName Get-Variable -MockWith {}
-            Get-IDSession
+
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = 'SomeUser'
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = (Get-Date).AddMinutes(-5)
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = (Get-Date).AddMinutes(-1)
+                LastCommandResults = @{'TestKey' = 'TestValue' }
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
+            $response = Get-IDSession
 
         }
 
         Context 'General' {
 
-            It 'gets expected variable' {
+            It 'provides output' {
 
-                Assert-MockCalled Get-Variable -ParameterFilter {
-
-                    $Name -eq 'WebSession'
-
-                } -Times 1 -Exactly -Scope It
+                $response | Should -Not -BeNullOrEmpty
 
             }
 
-            It 'gets variable from expected scope' {
+            It 'has output with expected number of properties' {
 
-                Assert-MockCalled Get-Variable -ParameterFilter {
-
-                    $Scope -eq 'Script'
-
-                } -Times 1 -Exactly -Scope It
+                $response.Keys.Count | Should -Be 10
 
             }
 
-            It 'gets variable value' {
+            It 'outputs object with expected typename' {
 
-                Assert-MockCalled Get-Variable -ParameterFilter {
-
-                    $ValueOnly -eq $true
-
-                } -Times 1 -Exactly -Scope It
+                $response | Get-Member | Select-Object -ExpandProperty typename -Unique | Should -Be IdCmd.Session
 
             }
 

--- a/Tests/Get-IDTenant.Tests.ps1
+++ b/Tests/Get-IDTenant.Tests.ps1
@@ -24,6 +24,21 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
+
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
+
             Mock Invoke-IDRestMethod -MockWith {
                 [pscustomobject]@{'property' = 'value' }
             }

--- a/Tests/Get-IDTenantCname.Tests.ps1
+++ b/Tests/Get-IDTenantCname.Tests.ps1
@@ -24,6 +24,21 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
+
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
+
             Mock Invoke-IDRestMethod -MockWith {
                 [pscustomobject]@{'property' = 'value' }
             }

--- a/Tests/Get-IDTenantConfiguration.Tests.ps1
+++ b/Tests/Get-IDTenantConfiguration.Tests.ps1
@@ -24,6 +24,20 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
+
             Mock Invoke-IDRestMethod -MockWith {
                 [pscustomobject]@{'property' = 'value' }
             }

--- a/Tests/Get-IDUser.Tests.ps1
+++ b/Tests/Get-IDUser.Tests.ps1
@@ -24,7 +24,20 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-            $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
+
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
         }
 
         Context 'GetUsers' {
@@ -110,7 +123,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 Mock Invoke-IDRestMethod -MockWith {
                     [pscustomobject]@{ 'property' = 'value' }
                 }
-                $response = Get-IDUser -id someid
+                $response = Get-IDUser -ID someid
             }
 
 
@@ -254,7 +267,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                 Mock Invoke-IDRestMethod -MockWith {
                     [pscustomobject]@{ 'property' = 'value' }
                 }
-                $response = Get-IDUser -currentuser
+                $response = Get-IDUser -CurrentUser
             }
 
             It 'sends request' {

--- a/Tests/Get-IDUserIdentifier.Tests.ps1
+++ b/Tests/Get-IDUserIdentifier.Tests.ps1
@@ -25,7 +25,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
         BeforeEach {
 
-            $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
 
             Mock Invoke-IDRestMethod -MockWith {
                 [pscustomobject]@{'property' = 'value' }

--- a/Tests/Get-IDUserRole.Tests.ps1
+++ b/Tests/Get-IDUserRole.Tests.ps1
@@ -27,7 +27,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             BeforeEach {
                 Mock Invoke-IDRestMethod -MockWith { @{SomeProperty = 'SomeValue' } }
-                $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
+                $ISPSSSession = [ordered]@{
+                    tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                    User               = $null
+                    TenantId           = 'SomeTenant'
+                    SessionId          = 'SomeSession'
+                    WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                    StartTime          = $null
+                    ElapsedTime        = $null
+                    LastCommand        = $null
+                    LastCommandTime    = $null
+                    LastCommandResults = $null
+                }
+                New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
                 $response = Get-IDUserRole -ID 1234 -Limit 1 -SortBy String
 
             }

--- a/Tests/Get-ParentFunction.Tests.ps1
+++ b/Tests/Get-ParentFunction.Tests.ps1
@@ -1,0 +1,86 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+	BeforeAll {
+		#Get Current Directory
+		$Here = Split-Path -Parent $PSCommandPath
+
+		#Assume ModuleName from Repository Root folder
+		$ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+		#Resolve Path to Module Directory
+		$ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+		#Define Path to Module Manifest
+		$ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+		if ( -not (Get-Module -Name $ModuleName -All)) {
+
+			Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+		}
+
+		$Script:RequestBody = $null
+		$psPASSession = [ordered]@{
+			BaseURI            = 'https://SomeURL/SomeApp'
+			User               = $null
+			ExternalVersion    = [System.Version]'0.0'
+			WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+			StartTime          = $null
+			ElapsedTime        = $null
+			LastCommand        = $null
+			LastCommandTime    = $null
+			LastCommandResults = $null
+		}
+
+		New-Variable -Name psPASSession -Value $psPASSession -Scope Script -Force
+
+	}
+
+
+	AfterAll {
+
+		$Script:RequestBody = $null
+
+	}
+
+	InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+		It 'returns parent function name' {
+			Function Test-Parent { Test-Child }
+			Function Test-Child { Get-ParentFunction }
+			$ThisTest = Test-Parent
+
+			$ThisTest.FunctionName | Should -Be Test-Parent
+		}
+
+		It 'returns expected parent function name from expected scope' {
+			Function Test-Example {
+				[CmdletBinding()]
+				param([parameter(ParameterSetName = 'ExampleParamSet')][string]$Name)
+				Test-Parent
+			}
+			Function Test-Parent { Test-Child }
+			Function Test-Child { Get-ParentFunction -Scope 3 }
+			$ThisTest = Test-Example -Name 'test'
+
+			$ThisTest.FunctionName | Should -Be 'Test-Example'
+
+		}
+
+		It 'returns expected ParameterSetName from expected scope' {
+			Function Test-Example {
+				[CmdletBinding()]
+				param([parameter(ParameterSetName = 'ExampleParamSet')][string]$Name)
+				Test-Parent
+			}
+			Function Test-Parent { Test-Child }
+			Function Test-Child { Get-ParentFunction -Scope 3 }
+			$ThisTest = Test-Example -Name 'test'
+
+			$ThisTest.ParameterSetName | Should -Be 'ExampleParamSet'
+		}
+
+
+	}
+
+}

--- a/Tests/Get-SessionClone.Tests.ps1
+++ b/Tests/Get-SessionClone.Tests.ps1
@@ -1,0 +1,96 @@
+Describe $($PSCommandPath -Replace '.Tests.ps1') {
+
+    BeforeAll {
+
+        #Get Current Directory
+        $Here = Split-Path -Parent $PSCommandPath
+
+        #Assume ModuleName from Repository Root folder
+        $ModuleName = Split-Path (Split-Path $Here -Parent) -Leaf
+
+        #Resolve Path to Module Directory
+        $ModulePath = Resolve-Path "$Here\..\$ModuleName"
+
+        #Define Path to Module Manifest
+        $ManifestPath = Join-Path "$ModulePath" "$ModuleName.psd1"
+
+        if ( -not (Get-Module -Name $ModuleName -All)) {
+
+            Import-Module -Name "$ManifestPath" -ArgumentList $true -Force -ErrorAction Stop
+
+        }
+
+        $Script:RequestBody = $null
+
+    }
+
+
+    AfterAll {
+
+        $Script:RequestBody = $null
+
+    }
+
+    InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
+
+        Context 'Mandatory Parameters' {
+
+            $Parameters = @{Parameter = 'InputObject' }
+
+            It 'specifies parameter <Parameter> as mandatory' -TestCases $Parameters {
+
+                param($Parameter)
+
+				(Get-Command Get-SessionClone).Parameters["$Parameter"].Attributes.Mandatory | Should -Be $true
+
+            }
+
+        }
+
+        Context 'General' {
+
+            BeforeAll {
+                $psPASSession = [ordered]@{
+                    BaseURI            = 'https://SomeURL/SomeApp'
+                    User               = 'SomeUser'
+                    ExternalVersion    = [System.Version]'0.0'
+                    WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                    StartTime          = (Get-Date).AddMinutes(-5)
+                    ElapsedTime        = '{0:HH:mm:ss}' -f [datetime](Get-Date)
+                    LastCommand        = (Get-Variable MyInvocation).Value
+                    LastCommandTime    = (Get-Date).AddMinutes(-1)
+                    LastCommandResults = @{'TestProperty' = 'TestValue' }
+                }
+
+                New-Variable -Name object -Value $psPASSession -Scope Script -Force
+                $script:Clone = Get-SessionClone -InputObject $script:object
+            }
+
+            It 'returns output of expected type' {
+
+                $script:Clone | Should -BeOfType 'System.Collections.Specialized.OrderedDictionary'
+
+            }
+            It 'produces expected output properties' {
+
+                $script:Clone.keys | Should -HaveCount 9
+
+            }
+
+            It 'produces output that does not reference the input instance' {
+
+                [System.Object]::ReferenceEquals($script:object, $script:Clone) | Should -BeFalse
+
+            }
+
+            It 'outputs nested hashtable property that does not reference the input instance' {
+
+                [System.Object]::ReferenceEquals($script:object.LastCommandResults, $script:Clone.LastCommandResults) | Should -BeFalse
+
+            }
+
+        }
+
+    }
+
+}

--- a/Tests/Invoke-IDRestMethod.Tests.ps1
+++ b/Tests/Invoke-IDRestMethod.Tests.ps1
@@ -27,6 +27,20 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			BeforeEach {
 
+				$ISPSSSession = [ordered]@{
+					tenant_url         = $null
+					User               = $null
+					TenantId           = $null
+					SessionId          = $null
+					WebSession         = $null
+					StartTime          = $null
+					ElapsedTime        = $null
+					LastCommand        = $null
+					LastCommandTime    = $null
+					LastCommandResults = $null
+				}
+				New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
+
 				$Response = New-MockObject -Type Microsoft.PowerShell.Commands.WebResponseObject
 				$Response | Add-Member -MemberType NoteProperty -Name StatusCode -Value 200 -Force
 				$Response | Add-Member -MemberType NoteProperty -Name Headers -Value @{ 'Content-Type' = 'application/json; charset=utf-8' } -Force
@@ -117,12 +131,12 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			It 'sets WebSession variable in the module scope' {
 				Invoke-IDRestMethod @SessionVariable
-				$Script:WebSession | Should -Not -BeNullOrEmpty
+				$Script:ISPSSSession.WebSession | Should -Not -BeNullOrEmpty
 			}
 
 			It 'returns WebSession sessionvariable value' {
 				Invoke-IDRestMethod @SessionVariable
-				$Script:WebSession.Headers['Test'] | Should -Be 'OK'
+				$Script:ISPSSSession.WebSession.Headers['Test'] | Should -Be 'OK'
 			}
 
 			It 'sends output to Get-IDResponse' {
@@ -148,6 +162,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
 			BeforeEach {
 
+				$ISPSSSession = [ordered]@{
+					tenant_url         = $null
+					User               = $null
+					TenantId           = $null
+					SessionId          = $null
+					WebSession         = $null
+					StartTime          = $null
+					ElapsedTime        = $null
+					LastCommand        = $null
+					LastCommandTime    = $null
+					LastCommandResults = $null
+				}
+				New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
 				If ($IsCoreCLR) {
 					$errorDetails = $([pscustomobject]@{'ErrorCode' = 'URA999'; 'ErrorMessage' = 'Some Error Message' } | ConvertTo-Json)
 					$statusCode = 400

--- a/Tests/Invoke-IDSqlcmd.Tests.ps1
+++ b/Tests/Invoke-IDSqlcmd.Tests.ps1
@@ -24,7 +24,20 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-            $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
+
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
         }
 
         Context 'GetUsers' {

--- a/Tests/Lock-IDUser.Tests.ps1
+++ b/Tests/Lock-IDUser.Tests.ps1
@@ -27,7 +27,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             BeforeEach {
                 Mock Invoke-IDRestMethod -MockWith { [string]'TRUE' }
-                $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
+                $ISPSSSession = [ordered]@{
+                    tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                    User               = $null
+                    TenantId           = 'SomeTenant'
+                    SessionId          = 'SomeSession'
+                    WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                    StartTime          = $null
+                    ElapsedTime        = $null
+                    LastCommand        = $null
+                    LastCommandTime    = $null
+                    LastCommandResults = $null
+                }
+                New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
                 $response = Lock-IDUser -user 1234
 
             }

--- a/Tests/New-IDPlatformToken.Tests.ps1
+++ b/Tests/New-IDPlatformToken.Tests.ps1
@@ -25,6 +25,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
         BeforeEach {
 
+            $ISPSSSession = [ordered]@{
+                tenant_url         = $null
+                User               = $null
+                TenantId           = $null
+                SessionId          = $null
+                WebSession         = $null
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
             Mock Invoke-IDRestMethod -MockWith {
                 [pscustomobject]@{
                     token_type   = 'SomeTokenType'
@@ -41,7 +54,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             It 'sets expected tenant_url with no trailing slash as script scope variable' {
                 New-IDPlatformToken -tenant_url https://sometenant.id.cyberark.cloud/ -Credential $Cred
-                $Script:tenant_url | Should -Be 'https://sometenant.id.cyberark.cloud'
+                $Script:ISPSSSession.tenant_url | Should -Be 'https://sometenant.id.cyberark.cloud'
             }
 
             It 'sends request' {

--- a/Tests/New-IDSession.Tests.ps1
+++ b/Tests/New-IDSession.Tests.ps1
@@ -24,7 +24,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
     InModuleScope $(Split-Path (Split-Path (Split-Path -Parent $PSCommandPath) -Parent) -Leaf ) {
 
         BeforeEach {
-
+            $ISPSSSession = [ordered]@{
+                tenant_url         = $null
+                User               = $null
+                TenantId           = $null
+                SessionId          = $null
+                WebSession         = $null
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
             Mock Start-Authentication -MockWith {
                 [pscustomobject]@{
                     TenantId         = 'SomeID'
@@ -69,7 +81,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             It 'sets expected tenant_url with no trailing slash as script scope variable' {
                 New-IDSession -tenant_url https://somedomain.id.cyberark.cloud/ -Credential $Creds
-                $Script:tenant_url | Should -Be 'https://somedomain.id.cyberark.cloud'
+                $Script:ISPSSSession.tenant_url | Should -Be 'https://somedomain.id.cyberark.cloud'
 
             }
 
@@ -115,13 +127,13 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             It 'sets expected tenantId with no trailing slash as script scope variable' {
                 New-IDSession -tenant_url https://somedomain.id.cyberark.cloud -Credential $Creds
-                $Script:tenantId | Should -Be 'SomeID'
+                $Script:ISPSSSession.tenantId | Should -Be 'SomeID'
 
             }
 
             It 'sets expected sessionId as script scope variable' {
                 New-IDSession -tenant_url https://somedomain.id.cyberark.cloud -Credential $Creds
-                $Script:sessionId | Should -Be 'SomeSession'
+                $Script:ISPSSSession.sessionId | Should -Be 'SomeSession'
 
             }
 

--- a/Tests/Start-AdvanceAuthentication.Tests.ps1
+++ b/Tests/Start-AdvanceAuthentication.Tests.ps1
@@ -25,10 +25,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
         BeforeEach {
             $Script:Version = '1.0'
-            $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
-            $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
-            $Script:TenantId = 'SomeTenant'
-            $Script:SessionId = 'SomeSession'
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = 'SomeTenant'
+                SessionId          = 'SomeSession'
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
             $Mechanism = [pscustomobject]@{
                 MechanismId = 'SomeMechanismId'
                 AnswerType  = 'Text'

--- a/Tests/Start-Authentication.Tests.ps1
+++ b/Tests/Start-Authentication.Tests.ps1
@@ -25,8 +25,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
         BeforeEach {
             $Script:Version = '1.0'
-            $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
-            $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = $null
+                SessionId          = $null
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
             $LogonRequest = @{ }
             $LogonRequest['Method'] = 'POST'
             $LogonRequest['SessionVariable'] = 'IDSession'
@@ -94,7 +105,7 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
                     [pscustomobject]@{'PodFqdn' = 'otherdomain.id.cyberark.cloud' }
                 }
                 $LogonRequest | Start-Authentication -Credential $Creds
-                $Script:tenant_url | Should -Be 'https://otherdomain.id.cyberark.cloud'
+                $Script:ISPSSSession.tenant_url | Should -Be 'https://otherdomain.id.cyberark.cloud'
             }
 
             It 'sends two requests if redirect URL returned' {

--- a/Tests/Start-SamlAuthentication.Tests.ps1
+++ b/Tests/Start-SamlAuthentication.Tests.ps1
@@ -25,8 +25,20 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
         BeforeEach {
             $Script:Version = '1.0'
-            $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
-            $Script:WebSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+
+            $ISPSSSession = [ordered]@{
+                tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                User               = $null
+                TenantId           = $null
+                SessionId          = $null
+                WebSession         = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+                StartTime          = $null
+                ElapsedTime        = $null
+                LastCommand        = $null
+                LastCommandTime    = $null
+                LastCommandResults = $null
+            }
+            New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
             $LogonRequest = @{ }
             $LogonRequest['Method'] = 'POST'
             $LogonRequest['SessionVariable'] = 'IDSession'

--- a/Tests/Suspend-IDUserMFA.Tests.ps1
+++ b/Tests/Suspend-IDUserMFA.Tests.ps1
@@ -27,8 +27,20 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             BeforeEach {
                 Mock Invoke-IDRestMethod -MockWith {  }
-                $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
-                $response = Suspend-IDUserMFA -id 1234
+                $ISPSSSession = [ordered]@{
+                    tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                    User               = $null
+                    TenantId           = $null
+                    SessionId          = $null
+                    WebSession         = $null
+                    StartTime          = $null
+                    ElapsedTime        = $null
+                    LastCommand        = $null
+                    LastCommandTime    = $null
+                    LastCommandResults = $null
+                }
+                New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
+                $response = Suspend-IDUserMFA -ID 1234
 
             }
 

--- a/Tests/Test-IDUserCloudLock.Tests.ps1
+++ b/Tests/Test-IDUserCloudLock.Tests.ps1
@@ -27,7 +27,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             BeforeEach {
                 Mock Invoke-IDRestMethod -MockWith { [string]'TRUE' }
-                $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
+                $ISPSSSession = [ordered]@{
+                    tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                    User               = $null
+                    TenantId           = $null
+                    SessionId          = $null
+                    WebSession         = $null
+                    StartTime          = $null
+                    ElapsedTime        = $null
+                    LastCommand        = $null
+                    LastCommandTime    = $null
+                    LastCommandResults = $null
+                }
+                New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
                 $response = Test-IDUserCloudLock -user 1234
 
             }

--- a/Tests/Unlock-IDUser.Tests.ps1
+++ b/Tests/Unlock-IDUser.Tests.ps1
@@ -27,7 +27,19 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             BeforeEach {
                 Mock Invoke-IDRestMethod -MockWith { [string]'TRUE' }
-                $Script:tenant_url = 'https://somedomain.id.cyberark.cloud'
+                $ISPSSSession = [ordered]@{
+                    tenant_url         = 'https://somedomain.id.cyberark.cloud'
+                    User               = $null
+                    TenantId           = $null
+                    SessionId          = $null
+                    WebSession         = $null
+                    StartTime          = $null
+                    ElapsedTime        = $null
+                    LastCommand        = $null
+                    LastCommandTime    = $null
+                    LastCommandResults = $null
+                }
+                New-Variable -Name ISPSSSession -Value $ISPSSSession -Scope Script -Force
                 $response = Unlock-IDUser -user 1234
 
             }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 0.1.{build}
+version: 0.2.{build}
 
 environment:
   #GIT_TRACE: 1

--- a/docs/collections/_commands/Get-IDSession.md
+++ b/docs/collections/_commands/Get-IDSession.md
@@ -17,16 +17,31 @@ Get-IDSession [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Exports the WebSession object from the IdentityCommand module scope for use in other requests outside of the module scope.
+Exports variables like the URL, Username & WebSession object from the IdentityCommand module scope, either for use in other requests outside of the module scope, or for informational purposes.
+
+Return data also includes details such as session start time, elapsed time, last command time, as well as data for the last invoked command and the results of the previous command.
 
 ## EXAMPLES
 
 ### Example 1
 ```
 PS C:\> Get-IDSession
+
+Name                           Value
+----                           -----
+tenant_url                     https://abc1234.id.cyberark.cloud
+User                           some.user@somedomain.com
+TenantId                       ABC1234
+SessionId                      1337CbGbPunk3Sm1ff5ess510nD3tai75
+WebSession                     Microsoft.PowerShell.Commands.WebRequestSession
+StartTime                      12/02/2024 22:58:13
+ElapsedTime                    00:25:30
+LastCommand                    System.Management.Automation.InvocationInfo
+LastCommandTime                12/02/2024 23:23:07
+LastCommandResults             {"success":true,"Result":{"SomeResult"}}
 ```
 
-Output the IdentityCommand WebSession object for the current authenticated session.
+Output the IdentityCommand module scope session details, including the WebSession object for the current authenticated session.
 
 ## PARAMETERS
 


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

Updates the `Get-IDSession` command, which can be used to return data from the module scope:

```powershell
PS C:\> Get-IDSession

Name                           Value
----                           -----
tenant_url                     https://abc1234.id.cyberark.cloud
User                           some.user@somedomain.com
TenantId                       ABC1234
SessionId                      1337CbGbPunk3Sm1ff5ess510nD3tai75
WebSession                     Microsoft.PowerShell.Commands.WebRequestSession
StartTime                      12/02/2024 22:58:13
ElapsedTime                    00:25:30
LastCommand                    System.Management.Automation.InvocationInfo
LastCommandTime                12/02/2024 23:23:07
LastCommandResults             {"success":true,"Result":{"SomeResult"}}
```

Executing this command exports variables like the URL, Username & WebSession object for the authenticated session from IdentityCommand into your local scope, either for use in other requests outside of the module scope, or for informational purposes.

Return data also includes details such as session start time, elapsed time, last command time, as well as data for the last invoked command and the results of the previous command useful for debugging & development purposes.

### Added
- Private Function `Get-ParentFunction`
  - Helper function to get command invocation data from different scopes
- Private Function `Get-SessionClone`
  - Helper function to create unreferenced copy of IdentityCommand session hashtable object

### Changed
- `Get-IDSession`
  - Returns the module scoped `$ISPSSSession` variable (which includes the WebSession object), instead of just the WebSession object.
- `New-IDSession`
  - Sets values in the script scope `$ISPSSSession` object instead of individual script scope variables.
- `Close-IDSession`
  - Sets null values in the script scope `$ISPSSSession` object instead of removing individual script scope variables.
- All other functions
  - Updated entire codebase to reference `$ISPSSSession` object instead of individual script scope variables.

### Fixed
- N/A

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [X] Documentation update
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [X] Pester test(s) updated
- [X] Pester test(s) passing

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new test failures or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have opened & linked a related issue
- [ ] I have linked a related issue