### PR TITLE
Out of band idp authentication support

### DIFF
--- a/IdentityCommand/Public/New-IDSession.ps1
+++ b/IdentityCommand/Public/New-IDSession.ps1
@@ -85,7 +85,8 @@ Function New-IDSession {
 
             'Credential' {
 
-                if ($IDSession.IdpRedirectUrl) {
+                #IdpRedirectShortUrl is only included in the response if the OobIdPAuth header is set to true
+                if ($IDSession.IdpRedirectShortUrl) {
                     Write-Host @"
 You are being redirected to your browser in order to authenticate to your external identity provider.
 If your browser does not open, click on the below URL to navigate to your identity provider.
@@ -93,7 +94,7 @@ If your browser does not open, click on the below URL to navigate to your identi
 $($IDSession.IdpRedirectShortUrl)
 "@
                     #Launches the user's default browser and navigates it to the external identity provider
-                    Start-Process $IDSession.IdpRedirectUrl
+                    Start-Process $IDSession.IdpRedirectShortUrl
 
                     $OobAuthStatusRequest = @{ }
                     $OobAuthStatusRequest['Method'] = 'POST'

--- a/IdentityCommand/Public/New-IDSession.ps1
+++ b/IdentityCommand/Public/New-IDSession.ps1
@@ -55,6 +55,9 @@ Function New-IDSession {
 
         $LogonRequest['Headers'] = @{'accept' = '*/*' }
 
+        #Must be passed in order to get the parameters needed for OOB IdP auth
+        $LogonRequest['Headers'].Add('OobIdPAuth', $true)
+
         switch ($PSCmdlet.ParameterSetName) {
 
             'Credential' {
@@ -81,6 +84,35 @@ Function New-IDSession {
         switch ($PSCmdlet.ParameterSetName) {
 
             'Credential' {
+
+                if ($IDSession.IdpRedirectUrl) {
+                    Write-Host @"
+You are being redirected to your browser in order to authenticate to your external identity provider.
+If your browser does not open, click on the below URL to navigate to your identity provider.
+
+$($IDSession.IdpRedirectShortUrl)
+"@
+                    #Launches the user's default browser and navigates it to the external identity provider
+                    Start-Process $IDSession.IdpRedirectUrl
+
+                    $OobAuthStatusRequest = @{ }
+                    $OobAuthStatusRequest['Method'] = 'POST'
+                    #Undocumented endpoint for checking the IdpLoginSessionId's status. Sniffed out from the ark-sdk-python project
+                    $OobAuthStatusRequest['Uri'] = "$tenant_url/Security/OobAuthStatus"
+                    #We need the cookies the server provides in the same response it provides the IdpAuth information
+                    $OobAuthStatusRequest['WebSession'] = $ISPSSSession.WebSession
+                    $OobAuthStatusRequest['Body'] = @{SessionId = $IDSession.IdpLoginSessionId} | ConvertTo-Json
+
+                    $IDSession = Invoke-IDRestMethod @OobAuthStatusRequest
+
+                    while ($IDSession.State -ne 'Success') {
+                        Start-Sleep 2
+
+                        $IDSession = Invoke-IDRestMethod @OobAuthStatusRequest
+                    }
+
+                    break
+                }
 
                 #The MFA Bit - keep a reference to $IDSession for the MFA Package
                 $ThisSession = $IDSession

--- a/IdentityCommand/en-US/IdentityCommand-help.xml
+++ b/IdentityCommand/en-US/IdentityCommand-help.xml
@@ -1249,7 +1249,7 @@ LastCommandResults             {"success":true,"Result":{"SomeResult"}}</dev:cod
       <maml:para>Use this command to authenticate to CyberArk Identity.</maml:para>
       <maml:para>Allows a user to provide authentication details, and satisfy any required MFA challenges.</maml:para>
       <maml:para>Currently supports all Identity MFA authentication mechanisms except U2F &amp; DUO.</maml:para>
-      <maml:para>Supports federated authentication when providing a SamlAssertion from a configured external IDP.</maml:para>
+      <maml:para>When you specify a username associated with a SAML or OIDC-based federation, then you will be redirected to the external identity provider to authenticate. Alternatively, you can provide a SamlAssertion from a configured external IDP.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>

--- a/Tests/New-IDSession.Tests.ps1
+++ b/Tests/New-IDSession.Tests.ps1
@@ -127,6 +127,16 @@ Describe $($PSCommandPath -Replace '.Tests.ps1') {
 
             }
 
+            It 'sends Start-Authentication request with OobIdpAuth header' {
+                New-IDSession -tenant_url https://somedomain.id.cyberark.cloud -Credential $Creds
+                Assert-MockCalled -CommandName Start-Authentication -Times 1 -Exactly -Scope It -ParameterFilter {
+
+                    $LogonRequest['Headers']['OobIdpAuth'] -eq $true
+
+                }
+
+            }
+
             It 'sets expected tenantId with no trailing slash as script scope variable' {
                 New-IDSession -tenant_url https://somedomain.id.cyberark.cloud -Credential $Creds
                 $Script:ISPSSSession.tenantId | Should -Be 'SomeID'


### PR DESCRIPTION
<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description
<!--
Please include a summary of the change and which issue is fixed & relevant motivation and context.
Put `Fixes #XXX` in your comment to link the issue that your PR fixes.
-->

This introduces out of band external identity provider support for authentication. This can be used in lieu of passing a SAML assertion in the `SAMLReponse` argument of `New-IDSession.`

This functionality isn't documented however it is used in [CyberArk's official python SDK](https://github.com/cyberark/ark-sdk-python).

Fixes #7  

## Type of change
<!--
Please select all relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [x] Documentation update
- [ ] Other (see description)

# How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes.
Demonstrate the code is solid (i.e. The exact commands you ran and the output).
Provide instructions so tests can be reproduce.
Confirm if existing module tests require update/are updated/are passing
-->

- [ ] Pester test(s) update required
- [x] Pester test(s) updated
- [x] Pester test(s) passing

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [x] My code follows the style guidelines of this project
- [x] I have followed the contributing guidelines.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new test failures or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have opened & linked a related issue
- [x] I have linked a related issue