### PR TITLE
Fix SMS 2FA

### DIFF
--- a/IdentityCommand/Private/Get-MechanismAnswer.ps1
+++ b/IdentityCommand/Private/Get-MechanismAnswer.ps1
@@ -50,7 +50,7 @@ function Get-MechanismAnswer {
 
         switch ($Mechanism.Name) {
 
-            'UP' {
+            { $PSItem -match 'UP|SMS' } {
 
                 #User Password already provided via Credential
                 $Answer = $Credential.Password
@@ -94,7 +94,7 @@ function Get-MechanismAnswer {
 
             }
 
-            { $PSItem -match 'SMS|OATH' } {
+            { $PSItem -match 'OATH' } {
 
                 #Prompt for TOTP/SMS code input
                 $Answer = Read-Host -Prompt $($Mechanism.PromptMechChosen) -AsSecureString

--- a/IdentityCommand/Private/Start-AdvanceAuthentication.ps1
+++ b/IdentityCommand/Private/Start-AdvanceAuthentication.ps1
@@ -94,6 +94,10 @@ Function Start-AdvanceAuthentication {
                         break
                     }
 
+                    { $PSItem.Name -match 'SMS' } {
+                        $Answer = Read-Host -Prompt $($Mechanism.PromptMechChosen) -AsSecureString
+                    }
+
                     { $($PSItem.Name) -match 'SQ|UP|OATH|SMS|RESET' } {
 
                         #Provide Answer Directly


### PR DESCRIPTION


<!-- A similar PR may already be submitted. Please search existing `Pull Requests` before creating one. -->
# Description

Resolve issue where using SMS 2FA resulted in script asking for 2FA code before 2FA code was sent to phone.

Fixes #21 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that makes existing functionality work differently)
- [ ] Documentation update
- [ ] Other (see description)

# How Has This Been Tested?
$Credential = Get-Credential
New-IdSession -tenant_url https://TENANT_ID.id.cyberark.cloud -Credential $Credential
Selected SMS option

- [ ] Pester test(s) update required
- [ ] Pester test(s) updated
- [ ] Pester test(s) passing

# Checklist:
<!--
See the `CONTRIBUTING` guide. _Ensure your code adheres to the project's PowerShell Styleguide_
Please select all relevant options:
-->
- [X] My code follows the style guidelines of this project
- [X] I have followed the contributing guidelines.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new test failures or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I have opened & linked a related issue
- [X] I have linked a related issue